### PR TITLE
Mention AUR package in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ cd pa_volume/
 make
 ```
 
+### AUR
+This program is available on the AUR for Arch Linux-based distributions as
+`pa_volume-git`.
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
I have packaged pa_volume for the AUR. Mentioning the package name makes it easier to find and install for Arch Linux users.